### PR TITLE
Error while deserialization for attributes

### DIFF
--- a/Core/src/Utils/ObjectSerializer.php
+++ b/Core/src/Utils/ObjectSerializer.php
@@ -121,6 +121,8 @@ class ObjectSerializer
                     $deserialized[$key] = self::deserialize($value, $subClassType, null);
                 }
             }
+
+            return $deserialized;
         } elseif (0 === strcasecmp(substr($responseType, -2), '[]')) {
             $response = is_string($response) ? json_decode($response) : $response;
             $subClassType = substr($responseType, 0, -2);


### PR DESCRIPTION
In release 3.1.61 was broken ObjectSerializer: return statement was removed from deserialize method.

At least it affects to ServerDetail object: always null value for addresses(and other attributes with type "map[*]")